### PR TITLE
Fixed meta.json for consecutive count

### DIFF
--- a/consecutive-count/meta.json
+++ b/consecutive-count/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Consecutive count",
-  "name": "counsecutive_count",
+  "name": "consecutive_count",
   "difficulty": "medium",
   "author": "Toranj",
   "category": "list-2"


### PR DESCRIPTION
function was called counsecutive instead of consecutive in meta.json resulting in the exercise not working properly